### PR TITLE
[AI - CODEX] Show streak and accuracy stats in GuessWords and GuessVerbs components

### DIFF
--- a/src/app/verbs/components/guess-verbs/guess-verbs.component.html
+++ b/src/app/verbs/components/guess-verbs/guess-verbs.component.html
@@ -26,6 +26,21 @@
         {{ message }}
       </div>
 
+      <div class="stats" aria-label="Statistici exercițiu">
+        <div class="stat">
+          <span class="stat-value">{{ currentStreak }}</span>
+          <span class="stat-label">serie</span>
+        </div>
+        <div class="stat">
+          <span class="stat-value">{{ bestStreak }}</span>
+          <span class="stat-label">record</span>
+        </div>
+        <div class="stat">
+          <span class="stat-value">{{ accuracy }}%</span>
+          <span class="stat-label">acuratețe</span>
+        </div>
+      </div>
+
       <div class="counter">Rămas de rezolvat: {{ exercisesLeftAmount }}</div>
 
       <div class="status">

--- a/src/app/verbs/components/guess-verbs/guess-verbs.component.scss
+++ b/src/app/verbs/components/guess-verbs/guess-verbs.component.scss
@@ -87,6 +87,39 @@ $font-family-main: "Segoe UI", "Roboto", sans-serif;
   }
 }
 
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  margin: 0 0 1rem;
+}
+
+.stat {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.07);
+  padding: 0.55rem 0.35rem;
+}
+
+.stat-value,
+.stat-label {
+  display: block;
+}
+
+.stat-value {
+  color: $color-correct;
+  font-size: 1.05rem;
+  font-weight: 800;
+}
+
+.stat-label {
+  color: $color-counter;
+  font-size: 0.72rem;
+  margin-top: 0.15rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
 .message {
   font-weight: 700;
   margin-bottom: 1rem;

--- a/src/app/verbs/components/guess-verbs/guess-verbs.component.spec.ts
+++ b/src/app/verbs/components/guess-verbs/guess-verbs.component.spec.ts
@@ -8,9 +8,8 @@ describe('GuessVerbsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [GuessVerbsComponent]
-    })
-    .compileComponents();
+      imports: [GuessVerbsComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(GuessVerbsComponent);
     component = fixture.componentInstance;
@@ -19,5 +18,35 @@ describe('GuessVerbsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should track streaks and accuracy', () => {
+    component.currentExercise = {
+      question: '(Prezent): eu ___ (a merge)',
+      correctAnswers: ['merg'],
+      type: 'conjugate-prezent',
+    };
+    component.guess = 'merg';
+
+    expect(component.trySubmit()).toBeTrue();
+    expect(component.guessed).toBe(1);
+    expect(component.currentStreak).toBe(1);
+    expect(component.bestStreak).toBe(1);
+    expect(component.accuracy).toBe(100);
+
+    component.loading = false;
+    component.currentExercise = {
+      question: '(Prezent): tu ___ (a merge)',
+      correctAnswers: ['mergi'],
+      type: 'conjugate-prezent',
+    };
+    component.guess = 'wrong';
+
+    component.submitGuess();
+
+    expect(component.missed).toBe(1);
+    expect(component.currentStreak).toBe(0);
+    expect(component.bestStreak).toBe(1);
+    expect(component.accuracy).toBe(50);
   });
 });

--- a/src/app/verbs/components/guess-verbs/guess-verbs.component.ts
+++ b/src/app/verbs/components/guess-verbs/guess-verbs.component.ts
@@ -40,6 +40,8 @@ export class GuessVerbsComponent implements OnInit {
   message = '';
   guessed = 0;
   missed = 0;
+  currentStreak = 0;
+  bestStreak = 0;
   loading = false;
   lastTried: string | null = null;
   hasExercises = false;
@@ -66,6 +68,16 @@ export class GuessVerbsComponent implements OnInit {
     return this.exercises.length;
   }
 
+  get totalAttempts() {
+    return this.guessed + this.missed;
+  }
+
+  get accuracy() {
+    if (!this.totalAttempts) return 0;
+
+    return Math.round((this.guessed / this.totalAttempts) * 100);
+  }
+
   get solvedText(): string {
     if (!this.currentExercise) return '';
 
@@ -77,6 +89,10 @@ export class GuessVerbsComponent implements OnInit {
   clearProgress() {
     this.storage.remove(this.STORAGE_KEY);
     this.solvedQuestions.clear();
+    this.guessed = 0;
+    this.missed = 0;
+    this.currentStreak = 0;
+    this.bestStreak = 0;
     this.buildExercises();
     this.nextExercise();
   }
@@ -272,13 +288,19 @@ export class GuessVerbsComponent implements OnInit {
     }
     const isCorrect = this.trySubmit();
     if (isCorrect) return;
-    if (this.lastTried !== this.currentExercise.question) this.missed++;
+    if (this.lastTried !== this.currentExercise.question) {
+      this.missed++;
+      this.currentStreak = 0;
+    }
+
     this.message = `Greșit!`;
     this.lastTried = this.currentExercise.question;
   }
 
   private guessTheWord() {
     this.guessed++;
+    this.currentStreak++;
+    this.bestStreak = Math.max(this.bestStreak, this.currentStreak);
     this.message = 'Corect';
     this.loading = true;
 

--- a/src/app/words/components/guess-words/guess-words.component.html
+++ b/src/app/words/components/guess-words/guess-words.component.html
@@ -26,6 +26,21 @@
       {{ message }}
     </div>
 
+    <div class="stats" aria-label="Statistici exercițiu">
+      <div class="stat">
+        <span class="stat-value">{{ currentStreak }}</span>
+        <span class="stat-label">serie</span>
+      </div>
+      <div class="stat">
+        <span class="stat-value">{{ bestStreak }}</span>
+        <span class="stat-label">record</span>
+      </div>
+      <div class="stat">
+        <span class="stat-value">{{ accuracy }}%</span>
+        <span class="stat-label">acuratețe</span>
+      </div>
+    </div>
+
     <div class="counter">Rămas de rezolvat: {{ exercisesLeftAmount }}</div>
     } @else { Nu au fost găsite exerciții. }
   </div>

--- a/src/app/words/components/guess-words/guess-words.component.scss
+++ b/src/app/words/components/guess-words/guess-words.component.scss
@@ -89,6 +89,39 @@ $font-family-main: "Segoe UI", "Roboto", sans-serif;
   }
 }
 
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  margin: 0 0 1rem;
+}
+
+.stat {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.07);
+  padding: 0.55rem 0.35rem;
+}
+
+.stat-value,
+.stat-label {
+  display: block;
+}
+
+.stat-value {
+  color: $color-correct;
+  font-size: 1.05rem;
+  font-weight: 800;
+}
+
+.stat-label {
+  color: $color-counter;
+  font-size: 0.72rem;
+  margin-top: 0.15rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
 .message {
   font-weight: 700;
   margin-bottom: 1rem;

--- a/src/app/words/components/guess-words/guess-words.component.spec.ts
+++ b/src/app/words/components/guess-words/guess-words.component.spec.ts
@@ -8,9 +8,8 @@ describe('GuessWordsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [GuessWordsComponent]
-    })
-    .compileComponents();
+      imports: [GuessWordsComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(GuessWordsComponent);
     component = fixture.componentInstance;
@@ -19,5 +18,35 @@ describe('GuessWordsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should track streaks and accuracy', () => {
+    component.currentExercise = {
+      question: 'Traducere în engleză: salut',
+      correctAnswers: ['hello'],
+      type: 'to-en',
+    };
+    component.guess = 'hello';
+
+    expect(component.trySubmit()).toBeTrue();
+    expect(component.guessed).toBe(1);
+    expect(component.currentStreak).toBe(1);
+    expect(component.bestStreak).toBe(1);
+    expect(component.accuracy).toBe(100);
+
+    component.loading = false;
+    component.currentExercise = {
+      question: 'Traducere în română: book',
+      correctAnswers: ['carte'],
+      type: 'to-ro',
+    };
+    component.guess = 'wrong';
+
+    component.submitGuess();
+
+    expect(component.missed).toBe(1);
+    expect(component.currentStreak).toBe(0);
+    expect(component.bestStreak).toBe(1);
+    expect(component.accuracy).toBe(50);
   });
 });

--- a/src/app/words/components/guess-words/guess-words.component.ts
+++ b/src/app/words/components/guess-words/guess-words.component.ts
@@ -34,6 +34,8 @@ export class GuessWordsComponent implements OnInit {
   message = '';
   guessed = 0;
   missed = 0;
+  currentStreak = 0;
+  bestStreak = 0;
   loading = false;
   lastTried: string | null = null;
 
@@ -52,6 +54,16 @@ export class GuessWordsComponent implements OnInit {
 
   get exercisesLeftAmount() {
     return this.exercises.length;
+  }
+
+  get totalAttempts() {
+    return this.guessed + this.missed;
+  }
+
+  get accuracy() {
+    if (!this.totalAttempts) return 0;
+
+    return Math.round((this.guessed / this.totalAttempts) * 100);
   }
 
   private buildExercises() {
@@ -124,13 +136,19 @@ export class GuessWordsComponent implements OnInit {
     const isCorrect = this.trySubmit();
     if (isCorrect) return;
 
-    if (this.lastTried !== this.currentExercise.question) this.missed++;
+    if (this.lastTried !== this.currentExercise.question) {
+      this.missed++;
+      this.currentStreak = 0;
+    }
+
     this.message = `Greșit!`;
     this.lastTried = this.currentExercise.question;
   }
 
   private guessTheWord() {
     this.guessed++;
+    this.currentStreak++;
+    this.bestStreak = Math.max(this.bestStreak, this.currentStreak);
     this.message = 'Corect!';
     this.loading = true;
     setTimeout(() => this.nextExercise(true), 1500);


### PR DESCRIPTION
### Motivation
- Surface per-exercise performance metrics (current streak, best streak, accuracy) in the guessing UIs to give users immediate feedback. 
- Track and update streak/accuracy state on correct and incorrect answers so the UI reflects real-time performance. 
- Add automated coverage for the new behavior to ensure correctness.

### Description
- Added a stats block to the templates in `guess-words.component.html` and `guess-verbs.component.html` that displays `currentStreak`, `bestStreak`, and `accuracy` percentages. 
- Introduced styles for the new UI in both `guess-words.component.scss` and `guess-verbs.component.scss` under the `.stats`/`.stat` rules. 
- Added `currentStreak`, `bestStreak`, `totalAttempts` getter, and `accuracy` getter to both components and updated logic so `guessTheWord()` increments streaks and updates `bestStreak`, while `submitGuess()` increments `missed` and resets `currentStreak` on first miss per question; `clearProgress()` now resets counters. 
- Extended unit specs (`guess-words.component.spec.ts` and `guess-verbs.component.spec.ts`) to include a test that verifies streak and accuracy tracking and adjusted `TestBed` setup formatting.

### Testing
- Ran unit tests including the new specs in `guess-words.component.spec.ts` and `guess-verbs.component.spec.ts`. 
- The new tests verify correct increments for `guessed`/`missed`, `currentStreak`/`bestStreak`, and computed `accuracy`. 
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09dc5a3b808323b206e615fd2c4803)