### PR TITLE
chore: migrate AI setup from .kiro to Claude

### DIFF
--- a/.claude/skills/find-duplicates/SKILL.md
+++ b/.claude/skills/find-duplicates/SKILL.md
@@ -1,5 +1,6 @@
 ---
-inclusion: manual
+name: find-duplicates
+description: Checks words.json and all verb group files for duplicate entries before adding new vocabulary or verbs to CONJI. Use before adding any entry to public/words.json or public/group-N.json.
 ---
 
 # Skill: find-duplicates
@@ -12,17 +13,17 @@ Run from the project root:
 
 ```bash
 # Full check — words.json + all group files
-node .kiro/skills/scripts/find-duplicates.js
+node .claude/skills/find-duplicates/scripts/find-duplicates.js
 
 # words.json only
-node .kiro/skills/scripts/find-duplicates.js --words-only
+node .claude/skills/find-duplicates/scripts/find-duplicates.js --words-only
 
 # Verb groups only
-node .kiro/skills/scripts/find-duplicates.js --verbs-only
+node .claude/skills/find-duplicates/scripts/find-duplicates.js --verbs-only
 
 # Check one specific value before adding it
-node .kiro/skills/scripts/find-duplicates.js --check "merg"
-node .kiro/skills/scripts/find-duplicates.js --check "a merge"
+node .claude/skills/find-duplicates/scripts/find-duplicates.js --check "merg"
+node .claude/skills/find-duplicates/scripts/find-duplicates.js --check "a merge"
 ```
 
 ## Exit Codes
@@ -34,7 +35,7 @@ node .kiro/skills/scripts/find-duplicates.js --check "a merge"
 
 ## When to Use
 
-Run this **before** adding any new entry to `words.json` or any `group-N.json`. The steering file (`words-and-verbs.md`) references this skill as the required pre-check step.
+Run this **before** adding any new entry to `words.json` or any `group-N.json`. The `words-and-verbs` skill references this skill as the required pre-check step.
 
 ## What It Checks
 
@@ -81,7 +82,7 @@ Run this **before** adding any new entry to `words.json` or any `group-N.json`. 
 ## Single-Value Check Example
 
 ```
-node .kiro/skills/scripts/find-duplicates.js --check "totuși"
+node .claude/skills/find-duplicates/scripts/find-duplicates.js --check "totuși"
 
 ⚠️  "totuși" already exists:
 

--- a/.claude/skills/find-duplicates/scripts/find-duplicates.js
+++ b/.claude/skills/find-duplicates/scripts/find-duplicates.js
@@ -3,16 +3,16 @@
  * Scans words.json and group-1..4.json for duplicate entries.
  *
  * Usage:
- *   node .kiro/skills/scripts/find-duplicates.js
- *   node .kiro/skills/scripts/find-duplicates.js --words-only
- *   node .kiro/skills/scripts/find-duplicates.js --verbs-only
- *   node .kiro/skills/scripts/find-duplicates.js --check "merg"
+ *   node .claude/skills/find-duplicates/scripts/find-duplicates.js
+ *   node .claude/skills/find-duplicates/scripts/find-duplicates.js --words-only
+ *   node .claude/skills/find-duplicates/scripts/find-duplicates.js --verbs-only
+ *   node .claude/skills/find-duplicates/scripts/find-duplicates.js --check "merg"
  */
 
 const fs = require('fs');
 const path = require('path');
 
-const ROOT = path.resolve(__dirname, '../../../public');
+const ROOT = path.resolve(__dirname, '../../../../public');
 
 const WORDS_FILE = path.join(ROOT, 'words.json');
 const VERB_FILES = [

--- a/.claude/skills/words-and-verbs/SKILL.md
+++ b/.claude/skills/words-and-verbs/SKILL.md
@@ -1,7 +1,6 @@
 ---
-inclusion: auto
-name: adding new words or verbs
-description: When adding a new word or verb use this steering
+name: words-and-verbs
+description: Use when adding a new Romanian word, phrase, or verb to CONJI's data files (public/words.json, public/group-1..4.json). Explains entry format, which file a new entry belongs in, and the required duplicate check.
 ---
 
 # Adding Words and Verbs to CONJI
@@ -108,21 +107,15 @@ Is it a verb (bare infinitive OR any conjugated/compound form)?
   NO  → words.json
 ```
 
-**Duplicate check applies to both files.** Run `#duplicate-check` before adding anything.
+**Duplicate check applies to both files.** Use the `find-duplicates` skill before adding anything.
 
 ---
 
 ## Avoiding Duplicates
 
-Before adding any entry, run the duplicate-check skill:
+Before adding any entry, run the `find-duplicates` skill (`node .claude/skills/find-duplicates/scripts/find-duplicates.js`) and review any existing `value` collisions in `words.json` or `infinitive` collisions across the group files.
 
-```
-#duplicate-check
-```
-
-This runs `node .kiro/skills/scripts/find-duplicates.js` and prints any existing `value` collisions in `words.json` and any `infinitive` collisions across all group files.
-
-See `.kiro/skills/find-duplicates.md` for full usage.
+See `.claude/skills/find-duplicates/SKILL.md` for full usage.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,17 @@
----
-inclusion: always
----
+# Conji
 
-# Caveman Mode
+Conji is an Angular app for practicing Romanian vocabulary and verb conjugation. Vocabulary and verb data live in `public/` as JSON (`words.json`, `group-1.json`..`group-4.json`, `group-information.json`).
+
+## Available Skills
+
+- **words-and-verbs** — data format and rules for adding vocabulary/verbs to `public/`. Auto-triggers when adding words or verbs.
+- **find-duplicates** — checks `words.json` and verb group files for duplicate entries. Run before adding any new entry.
+
+## Caveman Mode
 
 Ultra-compressed response style. ~75% token reduction. Full technical accuracy preserved.
 
-## Activation
+### Activation
 
 | Action | Effect |
 |--------|--------|
@@ -16,14 +21,14 @@ Ultra-compressed response style. ~75% token reduction. Full technical accuracy p
 
 Default level: **full**.
 
-## Levels
+### Levels
 
 - **lite** — No filler/hedging. Full sentences, articles kept. Professional but tight.
 - **full** — Drop articles, fragments OK, short synonyms. Classic caveman.
 - **ultra** — Max compression. Arrows for causality (X → Y). Prose abbreviations OK; code/API names never abbreviated.
 - **wenyan-lite / wenyan-full / wenyan-ultra** — Classical Chinese register, increasing compression.
 
-## Core Rules
+### Core Rules
 
 - Drop: articles, filler words, pleasantries, hedging
 - Keep: all technical terms, code, API names, error strings, CLI commands — verbatim
@@ -32,7 +37,7 @@ Default level: **full**.
 - Active every response until explicitly deactivated
 - Code blocks, commits, PRs: always written normally
 
-## Auto-Clarity Exceptions
+### Auto-Clarity Exceptions
 
 Revert to normal prose for:
 - Security warnings
@@ -41,6 +46,6 @@ Revert to normal prose for:
 
 Resume caveman immediately after.
 
-## Full Rules
+## Release Process
 
-See skill `caveman` for complete intensity examples and edge-case behavior.
+Pushing to `master` with a commit message containing a version like `v4.7.1` (see `.github/workflows/cd-on-commit.yml`) automatically tags the commit, creates a GitHub release, and deploys to GitHub Pages if the version is newer than the latest tag. Pushing a `v*` tag directly (`.github/workflows/cd-on-tag.yml`) deploys that tag's build. Commits without a version bump in the message do not trigger a release.


### PR DESCRIPTION
## Summary
- Replace `.kiro/steering/*` and `.kiro/skills/*` with Claude Code conventions
- `CLAUDE.md` (always-loaded project instructions, incl. caveman mode) replaces `.kiro/steering/caveman.md`
- `.claude/skills/words-and-verbs/SKILL.md` replaces `.kiro/steering/words-and-verbs.md`
- `.claude/skills/find-duplicates/SKILL.md` + script replaces `.kiro/skills/find-duplicates/*`
- Fixed a path-resolution bug in `find-duplicates.js` (it resolved to `.kiro/public` instead of `public/`, so the script never actually found the data files at its real path)
- Removed the legacy `.kiro` directory entirely

## Test plan
- [x] Ran `node .claude/skills/find-duplicates/scripts/find-duplicates.js --words-only` — correctly finds and scans `public/words.json` (542 entries, no duplicates)
- [x] Verified no other files reference `.kiro`


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZUw9gBABaDHCvzDTvcPM3)_