### PR TITLE
fix: detect version bump across merge commits in CD pipeline

### DIFF
--- a/.github/workflows/cd-on-commit.yml
+++ b/.github/workflows/cd-on-commit.yml
@@ -25,7 +25,11 @@ jobs:
         id: newtag
         shell: bash
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%B)
+          # Scan recent history, not just the tip commit: a non-squash PR merge
+          # puts a "Merge pull request ..." commit at the tip, which never carries
+          # the version bump itself. Recent commits are newest-first, so the
+          # leftmost match is the most recent version bump.
+          COMMIT_MSG=$(git log -20 --pretty=%B)
           if [[ $COMMIT_MSG =~ v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
             NEW_TAG="v${BASH_REMATCH[1]}"
             LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")


### PR DESCRIPTION
## Summary
- `cd-on-commit.yml` only checked `git log -1 --pretty=%B` (the tip commit) for a `vX.Y.Z` version bump to decide whether to tag/release/deploy.
- A regular (non-squash) PR merge puts a `Merge pull request #N from ...` commit at the tip of `master`, which never carries the version bump itself — so **merging a versioned PR silently skipped tagging, release, and deploy**. This is exactly what happened when PR #9 (the `.kiro` → Claude migration, commit message `v4.7.1 > chore: ...`) was merged: no `v4.7.1` tag/release was created.
- Fix: scan the last 20 commit messages (newest first) instead of just the tip, so the most recent version bump is still picked up regardless of merge strategy.
- This PR's own merge (`v4.7.2`) will be the first real end-to-end test of the fix, and — since 4.7.2 > 4.7.1 — will also retroactively cover the missed release.

## Test plan
- [x] Confirmed `master`'s tip commit after PR #9 merged is a merge commit with no version string, and the old `git log -1` logic would resolve `tag=` (skip) — reproduced by inspecting `git log origin/master`
- [ ] Confirm merging this PR triggers `cd-on-commit.yml` to create tag `v4.7.2`, a GitHub release, and a deploy run


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZUw9gBABaDHCvzDTvcPM3)_