### PR TITLE
fix: fetch full git history so version bump detection works

### DIFF
--- a/.github/workflows/cd-on-commit.yml
+++ b/.github/workflows/cd-on-commit.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
## Summary
- PR #10 tried to fix version-bump detection across merge commits by scanning `git log -20` instead of just the tip commit, but its own merge (expected to cut `v4.7.2`) silently skipped again.
- Root cause: `actions/checkout@v3` defaults to a **shallow clone** (`fetch-depth: 1`). The checked-out working copy only ever contains the single tip commit (and no tags), so `git log -20` saw one commit and `git describe --tags --abbrev=0` had no tags to compare against.
- Fix: set `fetch-depth: 0` on the checkout step so full history and tags are available to the version-detection and comparison logic.

## Test plan
- [x] Inspected the failed run for PR #10's merge (db66eb87) — confirmed `git log -1 --format='%H'` was the only ref fetched, and the "Determine new tag" step found nothing, skipping all downstream steps
- [ ] Confirm merging this PR triggers tag `v4.7.3`, a GitHub release, and a deploy run


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZUw9gBABaDHCvzDTvcPM3)_