### PR TITLE
Add chapter 4 to Trenul care nu oprește

### DIFF
--- a/plots/trenul-care-nu-opreste.md
+++ b/plots/trenul-care-nu-opreste.md
@@ -4,7 +4,7 @@ title: "Trenul care nu oprește"
 language: ro
 level: intermediate (A2-B1)
 status: ongoing
-chapters_written: 3
+chapters_written: 4
 content_path: public/book-contents/4e8b43b0-25a2-44bb-ad5f-20199e9c075b/
 ---
 
@@ -22,8 +22,11 @@ methodically strips away every normal reassurance: the night never turns to
 day, the train never reaches a station, and finally the person meant to be
 in control — the conductor — turns out to not exist on this train at all.
 The other passengers' eerie passivity becomes as unsettling as the train
-itself. As of chapter 3, the mystery is still fully open: no explanation,
-supernatural or otherwise, has been offered.
+itself. In chapter 4, Alex tries to settle the question physically — by
+walking to the front of the train — and instead discovers the train may be
+far longer than physically possible, or have no end at all. As of chapter
+4, the mystery is still fully open: no explanation, supernatural or
+otherwise, has been offered.
 
 ## Key Twists / Turning Points
 
@@ -40,13 +43,25 @@ supernatural or otherwise, has been offered.
    modern trains drive themselves"); Alex's watch hands don't move and his
    phone has no signal, no messages, no time at all — time itself may have
    stopped, not just the train's schedule.
+5. **The train may be endless** (Ch. 4) — Alex walks toward the front of
+   the train to find the locomotive; an old passenger tells him he tried
+   the same thing once and never found an end; Alex counts past fifty
+   identical carriages and loses count; a woman knitting says she no
+   longer remembers how long she's been traveling; when Alex tries to turn
+   back, the corridor behind him looks exactly like the one ahead — he can
+   no longer tell which way leads back to his seat.
 
 ## Ending (current, as written)
 
-The book has no resolution yet — chapter 3 ends on mounting dread rather
-than an answer: Alex senses that the other passengers "no longer expect
-anything," suggesting they may have quietly given up or accepted something
-Alex hasn't yet. The train is still moving, the night is still unbroken, and
+The book has no resolution yet — chapter 4 ends on mounting dread rather
+than an answer. Alex tried to resolve the mystery physically, by walking to
+the front of the train, and instead found evidence that made things worse:
+past fifty identical carriages with no landmark in sight, a passenger who
+no longer remembers how long she's been traveling, and a corridor that
+looks the same in both directions once he tries to turn back. The chapter
+closes on Alex's own unresolved guess — that the train is either
+impossibly long or has no end at all — without confirming either
+possibility. The train is still moving, the night is still unbroken, and
 the central mystery (where is this train going, and why won't it stop) is
 deliberately left open at the current end of the book.
 
@@ -81,12 +96,28 @@ deliberately left open at the current end of the book.
 - Ends on: Alex alone in his unease, the train still running through an
   endless night.
 
+### Chapter 4 — Vagoane fără număr (Countless Carriages)
+- Setting: Walking forward through the train's carriages, night, still
+  moving.
+- Beats: Alex sets off alone toward the front of the train to find the
+  locomotive; every carriage is identical; an old man tells him he tried
+  the same walk once and never found an end; Alex counts past fifty
+  carriages and loses count; tries a window and sees only darkness, no
+  landmarks; a woman knitting says she no longer remembers how long she's
+  been traveling; Alex tries to turn back but the corridor behind him looks
+  exactly like the one ahead.
+- Characters: Alex, an old man, a knitting woman.
+- Ends on: Alex's own guess, unconfirmed — the train may simply be far
+  longer than any normal train, or it may have no end at all.
+
 ## Characters
 
 - **Alex** — Protagonist. An ordinary commuter; observant, increasingly
   anxious; the only passenger who still questions what's happening.
 - Supporting: unnamed fellow passengers who range from oblivious to quietly
-  resigned; no named secondary characters yet.
+  resigned, including an old man who admits he once tried and failed to
+  find the front of the train, and a woman who has lost track of how long
+  she's been traveling; no named secondary characters yet.
 
 ## Setting & Tone
 
@@ -104,7 +135,7 @@ wrong situation as normal.
 
 ## Continuity Notes (for future chapters)
 
-Story is `ongoing` — content_length (3) matches chapters written so far but
+Story is `ongoing` — content_length (4) matches chapters written so far but
 the plot is intentionally unresolved. Open threads for future chapters:
 - Why the conductor's cabin is empty and who (if anyone) is truly in
   control of the train.
@@ -113,6 +144,22 @@ the plot is intentionally unresolved. Open threads for future chapters:
   situation but have given up questioning it.
 - Whether the train ever stops, and what "stopping" would even mean here
   (arrival vs. something more final).
+- Whether the train is finite-but-immense or genuinely endless — Chapter 4
+  deliberately leaves this unconfirmed; do not resolve it in one direction
+  without a strong narrative reason.
+- Alex has now tried walking toward the front; a natural next escalation
+  is trying the *other* direction (the last car, beyond where he found the
+  empty cabin in Ch. 2), or testing whether the carriages themselves ever
+  repeat exactly (same passengers reappearing, suggesting a loop rather
+  than infinite length).
 Any new chapter should escalate the uncanny tension gradually and preserve
 the ambiguity — avoid resolving the mystery with a mundane explanation too
 quickly, and avoid introducing supernatural machinery not hinted at yet.
+
+## Language Note
+
+Chapter 4 intentionally uses simpler vocabulary and shorter sentences than
+Chapters 1-3 (short clauses, everyday words), while still using conditional
+mood forms (aș, ar, m-aș) naturally in dialogue and narration — matching a
+beginner-friendly register. Keep this simpler register for future chapters
+of this book unless directed otherwise.

--- a/public/book-contents/4e8b43b0-25a2-44bb-ad5f-20199e9c075b/4.html
+++ b/public/book-contents/4e8b43b0-25a2-44bb-ad5f-20199e9c075b/4.html
@@ -1,0 +1,88 @@
+<div class="book-chapter">
+  <h2>CAPITOLUL 4 - Vagoane fără număr</h2>
+
+  <p>
+    Alex nu mai poate sta pe loc. Nimeni nu caută un răspuns. El se ridică
+    și merge singur spre fața trenului, spre locomotivă. Poate acolo găsește
+    un răspuns.
+  </p>
+
+  <p>
+    Trece dintr-un vagon în altul. Fiecare ușă se deschide la fel. Fiecare
+    vagon arată la fel: aceleași scaune, aceeași lumină slabă, aceiași
+    oameni tăcuți. Alex numără vagoanele, ca să știe cât a mers.
+  </p>
+
+  <p>Unu. Doi. Trei. Cinci. Zece.</p>
+
+  <p>
+    La al doisprezecelea vagon, un bărbat bătrân îl privește o clipă.
+  </p>
+
+  <div class="dialog">
+    <p><span class="speaker">Bărbatul:</span> Cauți ceva?</p>
+    <p><span class="speaker">Alex:</span> Caut capătul trenului. Locomotiva.</p>
+    <p>
+      <span class="speaker">Bărbatul:</span> Am încercat și eu. Aș vrea să
+      știu unde se termină, dar mergi, mergi... și tot sunt vagoane.
+    </p>
+  </div>
+
+  <p>
+    Alex vrea să zâmbească, dar nu poate. Merge mai departe. Douăzeci de
+    vagoane. Treizeci. Patruzeci. Un tren normal n-ar avea atât de multe
+    vagoane. Dar ușa următoare se deschide la fel de ușor ca prima.
+  </p>
+
+  <p>
+    Aerul este cald în fiecare vagon. Roțile fac același sunet pe șine. Nu
+    este nicio curbă. Alex se uită pe geam. Ar vrea să vadă o lumină, un
+    deal, ceva. Dar afară este numai întuneric, la fel ca la început.
+  </p>
+
+  <p>
+    Într-un vagon, o femeie tricotează. Ea nu se oprește din lucru.
+  </p>
+
+  <div class="dialog">
+    <p><span class="speaker">Alex:</span> Scuzați, știți cât de lung este trenul?</p>
+    <p><span class="speaker">Femeia:</span> Lung? Nu m-am gândit la asta de mult timp.</p>
+    <p><span class="speaker">Alex:</span> De cât timp călătoriți?</p>
+    <p><span class="speaker">Femeia:</span> Nu mai știu. Cred că e mai bine așa.</p>
+  </div>
+
+  <p>
+    Răspunsul ei îl sperie mai tare decât tăcerea celorlalți. Alex merge
+    mai repede acum. Treizeci de vagoane devin patruzeci. Patruzeci devin
+    cincizeci. Picioarele îl dor, dar nu vrea să se oprească.
+  </p>
+
+  <p>
+    Pierde numărul undeva după al cincizecilea vagon. Numerele nu mai
+    contează. Vede același culoar, iar și iar, ca o oglindă în fața altei
+    oglinzi.
+  </p>
+
+  <p>
+    Se oprește. Respiră greu. «M-aș întoarce», se gândește el, «dar nu știu
+    drumul». Când privește în spate, culoarul arată la fel ca cel din față:
+    aceleași scaune, aceeași lumină, aceiași oameni.
+  </p>
+
+  <div class="dialog">
+    <p><span class="speaker">Alex:</span> (în șoaptă) Nu poate fi atât de lung...</p>
+  </div>
+
+  <p>
+    Alex stă nemișcat un moment. Ascultă doar roțile și respirația lui.
+    Nimeni din jur nu pare să vadă că a trecut atâta timp, sau că a mers
+    atât de mult fără să ajungă nicăieri.
+  </p>
+
+  <p>
+    Poate trenul este pur și simplu foarte lung. Atât de lung, încât nimeni
+    nu-i găsește capătul. Sau poate, se gândește Alex cu frică, nu are
+    capăt deloc — nici în față, nici în spate. Doar vagoane, unul după
+    altul, fără sfârșit, prin aceeași noapte care nu se termină niciodată.
+  </p>
+</div>

--- a/public/books.json
+++ b/public/books.json
@@ -9,6 +9,6 @@
     "id": "4e8b43b0-25a2-44bb-ad5f-20199e9c075b",
     "title": "Trenul care nu oprește",
     "description": "Aceasta este o poveste despre un tren pierdut. Noaptea nu se termină niciodată, trenul nu oprește, iar oamenii caută răspunsuri și speranță.",
-    "content_length": 3
+    "content_length": 4
   }
 ]


### PR DESCRIPTION
## Summary

- Added a new chapter (`public/book-contents/4e8b43b0-25a2-44bb-ad5f-20199e9c075b/4.html`) to "Trenul care nu oprește": Alex walks toward the front of the train counting carriages, and the chapter closes with the ambiguous discovery that the train may simply be far longer than any normal train, or may have no end at all.
- Written in simpler, beginner-friendly Romanian (short sentences, everyday vocabulary) with natural use of conditional mood forms (`aș`, `ar`, `m-aș`), per the requested reading level for this chapter.
- Updated `public/books.json` — `content_length: 3 → 4` for this book.
- Updated `plots/trenul-care-nu-opreste.md` — bumped `chapters_written`, added the Chapter 4 breakdown, a new twist entry, updated the Ending section, added continuity notes for future chapters, and a language note documenting the simpler register used in this chapter.
- Commit message includes `v4.8.0` (minor bump from `v4.7.4`) so `cd-on-commit.yml` tags/releases/deploys automatically once merged.

## Test plan

- [x] Reviewed chapter HTML follows the existing `book-chapter`/`dialog` markup structure used by chapters 1-3.
- [x] Verified `books.json` content_length matches the number of chapter files on disk.
- [x] Cross-checked the plot doc against the new chapter for consistency.
- [ ] Manually read the new chapter in the deployed app's book reader after merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQLscCcXVqJfJpSv4xDB8L)_